### PR TITLE
Broken link in footer to privacy policy

### DIFF
--- a/inix
+++ b/inix
@@ -1,2 +1,1 @@
 inix
- nuIYRJiIN7


### PR DESCRIPTION
The privacy policy link in the footer redirects to a 404 page, preventing users from accessing the document.