### PR TITLE
Profile picture upload not working

### DIFF
--- a/inix
+++ b/inix
@@ -1,1 +1,1 @@
-inix GJhiJcSXSs
+inix


### PR DESCRIPTION
Users report that uploading a profile picture results in a 'File type not supported' error, even with valid image formats.