### PR TITLE
File download links generate 'Access Denied' error

### DIFF
--- a/inix
+++ b/inix
@@ -1,1 +1,1 @@
-inix KulcCRuyck
+inix


### PR DESCRIPTION
Users receive an 'Access Denied' error when attempting to download files they have permission to access.