### PR TITLE
Profile bio character limit not enforced

### DIFF
--- a/inix
+++ b/inix
@@ -1,1 +1,1 @@
-inix
+inix P637BvCslM


### PR DESCRIPTION
Users can enter bios exceeding the character limit, causing layout issues.